### PR TITLE
Revert and minor editor recognition

### DIFF
--- a/tool-labs/collab-rec/collab-rec-test.py
+++ b/tool-labs/collab-rec/collab-rec-test.py
@@ -25,7 +25,7 @@ import re
 import random
 import logging
 
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta
 
 from collaborator import CollabRecommender
 import pywikibot
@@ -113,9 +113,12 @@ def main():
     #            'Keith-264', 'Nyth83', 'Mmuroya', 'Navy2004', 'Secutor7',
     #            'Ranger Steve', 'MisterBee1966']
 
-    members = ['Kieran4']
+    members = ['Callinus']
     
     for member in members:
+
+        print(member)
+
         user = pywikibot.User(site, member)
         contribs = []
         for (page, revid, time, comment) in user.contributions(128,
@@ -123,10 +126,9 @@ def main():
             contribs.append(page.title())	
 
         # Calculate the cutoff date
-        cutoff = datetime.now(timezone.utc) - timedelta(days=args.cutoff*30)
+        cutoff = datetime.now() - timedelta(days=args.cutoff*30)
         matches = recommender.recommend(contribs, member, 'en', cutoff,
                                         nrecs=args.nrecs, backoff=1, test=args.test)
-        
         match_set = set([rec['item'] for rec in matches])
         overlap = match_set & all_members
         
@@ -136,6 +138,9 @@ def main():
         print('Got {n} recommendations for User:{user}'.format(n=len(match_set),
                                                                user=member))
         print('Overlap with all members: {0}'.format(len(overlap)))
+       
+        for i in range(0, len(match_set)):
+            print(match_set.pop())
 
     print('''Total statistics:
     Number of recommendations: {n}

--- a/tool-labs/collab-rec/collab-rec-test.py
+++ b/tool-labs/collab-rec/collab-rec-test.py
@@ -25,117 +25,124 @@ import re
 import random
 import logging
 
-from suggestbot.recommenders.collaborator import CollabRecommender
+from datetime import datetime, timezone, timedelta
+
+from collaborator import CollabRecommender
 import pywikibot
 
 def main():
-        # Parse CLI options
-        import argparse
+    # Parse CLI options
+    import argparse
+    
+    cli_parser = argparse.ArgumentParser(
+        description="Code for testing the collaborator recommender"
+    )
         
-        cli_parser = argparse.ArgumentParser(
-                description="Code for testing the collaborator recommender"
-        )
+    # Add verbosity option
+    cli_parser.add_argument('-v', '--verbose', action='store_true',
+                            help='I can has kittehtalkzalot?')
+    
+    cli_parser.add_argument('member_file', type=str,
+                            help='path to member file')
+    
+    # cli_parser.add_argument('k', type=int,
+    #                     help='size of random sample to draw')
+    
+    cli_parser.add_argument('nrecs', type=int,
+                            help='number of recommendations per user')
+    
+    cli_parser.add_argument('test', type=str,
+                            help='type of test to return recommendations from')
+
+    cli_parser.add_argument('cutoff', type=int,
+                            help='the number of 30-day months to use when fetching revisions')
+    
+    args = cli_parser.parse_args()
+    
+    if args.verbose:
+        logging.basicConfig(level=logging.DEBUG)
+
+    # Regular expression to match a member username in our membership file
+    member_re = re.compile('User talk[:](?P<username>[^\}]+)')
+
+    all_members = set()
+    
+    with open(args.member_file, 'r') as infile:
+        for line in infile:
+            match_obj = member_re.search(line.strip())
+            if match_obj is None:
+                print("None object")
+            else:
+                all_members.add(match_obj.group('username'))
+
+    # members = random.sample(all_members, args.k)
+    if args.test == 'coedit':
+        recommender = CollabRecommender(assoc_threshold=0)
+    else:
+        recommender = CollabRecommender()
         
-        # Add verbosity option
-        cli_parser.add_argument('-v', '--verbose', action='store_true',
-                                help='I can has kittehtalkzalot?')
-
-        cli_parser.add_argument('member_file', type=str,
-                                help='path to member file')
-
-        # cli_parser.add_argument('k', type=int,
-        #                     help='size of random sample to draw')
-
-        cli_parser.add_argument('nrecs', type=int,
-                                help='number of recommendations per user')
-
-        cli_parser.add_argument('test', type=str,
-                                help='type of test to return recommendations from')
-        
-        args = cli_parser.parse_args()
-        
-        if args.verbose:
-                logging.basicConfig(level=logging.DEBUG)
-
-        # Regular expression to match a member username in our membership file
-        member_re = re.compile('User talk[:](?P<username>[^\}]+)')
-
-        all_members = set()
-
-        with open(args.member_file, 'r') as infile:
-                for line in infile:
-                        match_obj = member_re.search(line.strip())
-                        if match_obj is None:
-                                print("None object")
-                        else:
-                               all_members.add(match_obj.group('username'))
-
-        # members = random.sample(all_members, args.k)
-        if args.test == 'coedit':
-                recommender = CollabRecommender(assoc_threshold=0)
-        else:
-                recommender = CollabRecommender()
-                
-        site = pywikibot.Site('en') 
+    site = pywikibot.Site('en') 
                
-        print("Beginning collaborator recommendation test")
+    print("Beginning collaborator recommendation test")
 
-        total_recs = 0
-        total_overlap = 0
+    total_recs = 0
+    total_overlap = 0
 
-        # members = ['Slatersteven', 'WerWil', 'Fnlayson', 'Drrcs15', 'Turbothy',
-        #            '21stCenturyGreenstuff', 'RGFI', 'Loesorion', 'Grahamdubya', 'Sioraf',
-        #            'Skittles the hog', 'Smoth 007', 'Superfly94', 'Ewulp', 'Dank', 'Magus732',
-        #            'Redmarkviolinist', 'The27thMaine', 'Kcdlp', 'Foxsch', 'Tdrss', 'URTh',
-        #            'Waase', 'L clausewitz', 'Judgedtwice', 'Choy4311', 'Codrinb', 'Smmurphy',
-        #            'Kliu1', 'Gowallabies', 'Secutor7', 'Moneywagon', 'Nostalgia of Iran',
-        #            'Linmhall', 'Karanacs', 'Dana boomer', 'Robotam', 'Fdsdh1', 'DanieB52',
-        #            'Rosiestep', 'Scholarus', 'Laurinavicius', 'Dapi89', 'UrbanTerrorist',
-        #            'AGK', 'Samuel Peoples', 'Sapphire', 'Catlemur', 'Martocticvs', 'Gparkes',
-        #            'Pratyya Ghosh', 'Eurocopter', 'Pahari Sahib', 'Seitzd', 'The Bushranger',
-        #            'Natobxl', 'MasterOfHisOwnDomain', 'Takashi kurita', 'TeunSpaans',
-        #            'Kierzek', 'WDGraham', 'Miborovsky', 'The lost library',
-        #            'Antidiskriminator', 'The ed17', 'Cliftonian', 'AshLin',
-        #            'GeneralizationsAreBad', 'MechaChrist', 'Joep01', 'Chris.w.braun',
-        #            'TBrandley', 'Marky48', 'Cplakidas', 'John', 'Nyth83', 'Elonka',
-        #            'Alexandru.demian', 'Martinp23', 'GermanJoe', 'P.Marlow', 'ryan.opel',
-        #            'Asarelah', 'Ian Rose', 'Pectory', 'KizzyB', 'MrDolomite', 'Leifern',
-        #            'Timeweaver', 'Ashashyou', 'Sumsum2010', 'Looper5920', 'Geira', 'Ackpriss',
-        #            'Binksternet', 'Lothar von Richthofen', 'Molestash', 'Srnec',
-        #            'Sasuke Sarutobi', '.marc.']
+    # members = ['Slatersteven', 'WerWil', 'Fnlayson', 'Drrcs15', 'Turbothy',
+    #            '21stCenturyGreenstuff', 'RGFI', 'Loesorion', 'Grahamdubya', 'Sioraf',
+    #            'Skittles the hog', 'Smoth 007', 'Superfly94', 'Ewulp', 'Dank', 'Magus732',
+    #            'Redmarkviolinist', 'The27thMaine', 'Kcdlp', 'Foxsch', 'Tdrss', 'URTh',
+    #            'Waase', 'L clausewitz', 'Judgedtwice', 'Choy4311', 'Codrinb', 'Smmurphy',
+    #            'Kliu1', 'Gowallabies', 'Secutor7', 'Moneywagon', 'Nostalgia of Iran',
+    #            'Linmhall', 'Karanacs', 'Dana boomer', 'Robotam', 'Fdsdh1', 'DanieB52',
+    #            'Rosiestep', 'Scholarus', 'Laurinavicius', 'Dapi89', 'UrbanTerrorist',
+    #            'AGK', 'Samuel Peoples', 'Sapphire', 'Catlemur', 'Martocticvs', 'Gparkes',
+    #            'Pratyya Ghosh', 'Eurocopter', 'Pahari Sahib', 'Seitzd', 'The Bushranger',
+    #            'Natobxl', 'MasterOfHisOwnDomain', 'Takashi kurita', 'TeunSpaans',
+    #            'Kierzek', 'WDGraham', 'Miborovsky', 'The lost library',
+    #            'Antidiskriminator', 'The ed17', 'Cliftonian', 'AshLin',
+    #            'GeneralizationsAreBad', 'MechaChrist', 'Joep01', 'Chris.w.braun',
+    #            'TBrandley', 'Marky48', 'Cplakidas', 'John', 'Nyth83', 'Elonka',
+    #            'Alexandru.demian', 'Martinp23', 'GermanJoe', 'P.Marlow', 'ryan.opel',
+    #            'Asarelah', 'Ian Rose', 'Pectory', 'KizzyB', 'MrDolomite', 'Leifern',
+    #            'Timeweaver', 'Ashashyou', 'Sumsum2010', 'Looper5920', 'Geira', 'Ackpriss',
+    #            'Binksternet', 'Lothar von Richthofen', 'Molestash', 'Srnec',
+    #            'Sasuke Sarutobi', '.marc.']
+    
+    # members = ['Kieran4', 'Brendandh', 'Gog the Mild', 'Seitzd', 'Robotam',
+    #            'Keith-264', 'Nyth83', 'Mmuroya', 'Navy2004', 'Secutor7',
+    #            'Ranger Steve', 'MisterBee1966']
 
-        # members = ['Kieran4', 'Brendandh', 'Gog the Mild', 'Seitzd', 'Robotam',
-        #            'Keith-264', 'Nyth83', 'Mmuroya', 'Navy2004', 'Secutor7',
-        #            'Ranger Steve', 'MisterBee1966']
+    members = ['Kieran4']
+    
+    for member in members:
+        user = pywikibot.User(site, member)
+        contribs = []
+        for (page, revid, time, comment) in user.contributions(128,
+                                                               namespaces = [0]):
+            contribs.append(page.title())	
 
-        members = ['Kieran4']
+        # Calculate the cutoff date
+        cutoff = datetime.now(timezone.utc) - timedelta(days=args.cutoff*30)
+        matches = recommender.recommend(contribs, member, 'en', cutoff,
+                                        nrecs=args.nrecs, backoff=1, test=args.test)
+        
+        match_set = set([rec['item'] for rec in matches])
+        overlap = match_set & all_members
+        
+        total_recs += len(match_set)
+        total_overlap += len(overlap)
 
-        for member in members:
-                user = pywikibot.User(site, member)
-                contribs = []
-                for (page, revid, time, comment) in user.contributions(128,
-                                                                       namespaces = [0]):
-                        contribs.append(page.title())	
+        print('Got {n} recommendations for User:{user}'.format(n=len(match_set),
+                                                               user=member))
+        print('Overlap with all members: {0}'.format(len(overlap)))
 
-                matches = recommender.recommend(contribs, member, 'en',
-                                                nrecs=args.nrecs, backoff=1, test=args.test)
-
-                match_set = set([rec['item'] for rec in matches])
-                overlap = match_set & all_members
-
-                total_recs += len(match_set)
-                total_overlap += len(overlap)
-
-                print('Got {n} recommendations for User:{user}'.format(n=len(match_set),
-                                                                       user=member))
-                print('Overlap with all members: {0}'.format(len(overlap)))
-
-        print('''Total statistics:
+    print('''Total statistics:
     Number of recommendations: {n}
     Overlap with all members: {o}
     % overlap: {p:.2}'''.format(n=total_recs, o=total_overlap,
                                 p=100*float(total_overlap)/float(total_recs)))
-        print('Recommendation test complete')
+    print('Recommendation test complete')
 	
 if __name__ == "__main__":
-        main()
+    main()

--- a/tool-labs/collab-rec/collab-rec-test.py
+++ b/tool-labs/collab-rec/collab-rec-test.py
@@ -25,124 +25,117 @@ import re
 import random
 import logging
 
-from datetime import datetime, timezone, timedelta
-
-from collaborator import CollabRecommender
+from suggestbot.recommenders.collaborator import CollabRecommender
 import pywikibot
 
 def main():
-    # Parse CLI options
-    import argparse
-    
-    cli_parser = argparse.ArgumentParser(
-        description="Code for testing the collaborator recommender"
-    )
+        # Parse CLI options
+        import argparse
         
-    # Add verbosity option
-    cli_parser.add_argument('-v', '--verbose', action='store_true',
-                            help='I can has kittehtalkzalot?')
-    
-    cli_parser.add_argument('member_file', type=str,
-                            help='path to member file')
-    
-    # cli_parser.add_argument('k', type=int,
-    #                     help='size of random sample to draw')
-    
-    cli_parser.add_argument('nrecs', type=int,
-                            help='number of recommendations per user')
-    
-    cli_parser.add_argument('test', type=str,
-                            help='type of test to return recommendations from')
-
-    cli_parser.add_argument('cutoff', type=int,
-                            help='the number of 30-day months to use when fetching revisions')
-    
-    args = cli_parser.parse_args()
-    
-    if args.verbose:
-        logging.basicConfig(level=logging.DEBUG)
-
-    # Regular expression to match a member username in our membership file
-    member_re = re.compile('User talk[:](?P<username>[^\}]+)')
-
-    all_members = set()
-    
-    with open(args.member_file, 'r') as infile:
-        for line in infile:
-            match_obj = member_re.search(line.strip())
-            if match_obj is None:
-                print("None object")
-            else:
-                all_members.add(match_obj.group('username'))
-
-    # members = random.sample(all_members, args.k)
-    if args.test == 'coedit':
-        recommender = CollabRecommender(assoc_threshold=0)
-    else:
-        recommender = CollabRecommender()
+        cli_parser = argparse.ArgumentParser(
+                description="Code for testing the collaborator recommender"
+        )
         
-    site = pywikibot.Site('en') 
+        # Add verbosity option
+        cli_parser.add_argument('-v', '--verbose', action='store_true',
+                                help='I can has kittehtalkzalot?')
+
+        cli_parser.add_argument('member_file', type=str,
+                                help='path to member file')
+
+        # cli_parser.add_argument('k', type=int,
+        #                     help='size of random sample to draw')
+
+        cli_parser.add_argument('nrecs', type=int,
+                                help='number of recommendations per user')
+
+        cli_parser.add_argument('test', type=str,
+                                help='type of test to return recommendations from')
+        
+        args = cli_parser.parse_args()
+        
+        if args.verbose:
+                logging.basicConfig(level=logging.DEBUG)
+
+        # Regular expression to match a member username in our membership file
+        member_re = re.compile('User talk[:](?P<username>[^\}]+)')
+
+        all_members = set()
+
+        with open(args.member_file, 'r') as infile:
+                for line in infile:
+                        match_obj = member_re.search(line.strip())
+                        if match_obj is None:
+                                print("None object")
+                        else:
+                               all_members.add(match_obj.group('username'))
+
+        # members = random.sample(all_members, args.k)
+        if args.test == 'coedit':
+                recommender = CollabRecommender(assoc_threshold=0)
+        else:
+                recommender = CollabRecommender()
+                
+        site = pywikibot.Site('en') 
                
-    print("Beginning collaborator recommendation test")
+        print("Beginning collaborator recommendation test")
 
-    total_recs = 0
-    total_overlap = 0
+        total_recs = 0
+        total_overlap = 0
 
-    # members = ['Slatersteven', 'WerWil', 'Fnlayson', 'Drrcs15', 'Turbothy',
-    #            '21stCenturyGreenstuff', 'RGFI', 'Loesorion', 'Grahamdubya', 'Sioraf',
-    #            'Skittles the hog', 'Smoth 007', 'Superfly94', 'Ewulp', 'Dank', 'Magus732',
-    #            'Redmarkviolinist', 'The27thMaine', 'Kcdlp', 'Foxsch', 'Tdrss', 'URTh',
-    #            'Waase', 'L clausewitz', 'Judgedtwice', 'Choy4311', 'Codrinb', 'Smmurphy',
-    #            'Kliu1', 'Gowallabies', 'Secutor7', 'Moneywagon', 'Nostalgia of Iran',
-    #            'Linmhall', 'Karanacs', 'Dana boomer', 'Robotam', 'Fdsdh1', 'DanieB52',
-    #            'Rosiestep', 'Scholarus', 'Laurinavicius', 'Dapi89', 'UrbanTerrorist',
-    #            'AGK', 'Samuel Peoples', 'Sapphire', 'Catlemur', 'Martocticvs', 'Gparkes',
-    #            'Pratyya Ghosh', 'Eurocopter', 'Pahari Sahib', 'Seitzd', 'The Bushranger',
-    #            'Natobxl', 'MasterOfHisOwnDomain', 'Takashi kurita', 'TeunSpaans',
-    #            'Kierzek', 'WDGraham', 'Miborovsky', 'The lost library',
-    #            'Antidiskriminator', 'The ed17', 'Cliftonian', 'AshLin',
-    #            'GeneralizationsAreBad', 'MechaChrist', 'Joep01', 'Chris.w.braun',
-    #            'TBrandley', 'Marky48', 'Cplakidas', 'John', 'Nyth83', 'Elonka',
-    #            'Alexandru.demian', 'Martinp23', 'GermanJoe', 'P.Marlow', 'ryan.opel',
-    #            'Asarelah', 'Ian Rose', 'Pectory', 'KizzyB', 'MrDolomite', 'Leifern',
-    #            'Timeweaver', 'Ashashyou', 'Sumsum2010', 'Looper5920', 'Geira', 'Ackpriss',
-    #            'Binksternet', 'Lothar von Richthofen', 'Molestash', 'Srnec',
-    #            'Sasuke Sarutobi', '.marc.']
-    
-    # members = ['Kieran4', 'Brendandh', 'Gog the Mild', 'Seitzd', 'Robotam',
-    #            'Keith-264', 'Nyth83', 'Mmuroya', 'Navy2004', 'Secutor7',
-    #            'Ranger Steve', 'MisterBee1966']
+        # members = ['Slatersteven', 'WerWil', 'Fnlayson', 'Drrcs15', 'Turbothy',
+        #            '21stCenturyGreenstuff', 'RGFI', 'Loesorion', 'Grahamdubya', 'Sioraf',
+        #            'Skittles the hog', 'Smoth 007', 'Superfly94', 'Ewulp', 'Dank', 'Magus732',
+        #            'Redmarkviolinist', 'The27thMaine', 'Kcdlp', 'Foxsch', 'Tdrss', 'URTh',
+        #            'Waase', 'L clausewitz', 'Judgedtwice', 'Choy4311', 'Codrinb', 'Smmurphy',
+        #            'Kliu1', 'Gowallabies', 'Secutor7', 'Moneywagon', 'Nostalgia of Iran',
+        #            'Linmhall', 'Karanacs', 'Dana boomer', 'Robotam', 'Fdsdh1', 'DanieB52',
+        #            'Rosiestep', 'Scholarus', 'Laurinavicius', 'Dapi89', 'UrbanTerrorist',
+        #            'AGK', 'Samuel Peoples', 'Sapphire', 'Catlemur', 'Martocticvs', 'Gparkes',
+        #            'Pratyya Ghosh', 'Eurocopter', 'Pahari Sahib', 'Seitzd', 'The Bushranger',
+        #            'Natobxl', 'MasterOfHisOwnDomain', 'Takashi kurita', 'TeunSpaans',
+        #            'Kierzek', 'WDGraham', 'Miborovsky', 'The lost library',
+        #            'Antidiskriminator', 'The ed17', 'Cliftonian', 'AshLin',
+        #            'GeneralizationsAreBad', 'MechaChrist', 'Joep01', 'Chris.w.braun',
+        #            'TBrandley', 'Marky48', 'Cplakidas', 'John', 'Nyth83', 'Elonka',
+        #            'Alexandru.demian', 'Martinp23', 'GermanJoe', 'P.Marlow', 'ryan.opel',
+        #            'Asarelah', 'Ian Rose', 'Pectory', 'KizzyB', 'MrDolomite', 'Leifern',
+        #            'Timeweaver', 'Ashashyou', 'Sumsum2010', 'Looper5920', 'Geira', 'Ackpriss',
+        #            'Binksternet', 'Lothar von Richthofen', 'Molestash', 'Srnec',
+        #            'Sasuke Sarutobi', '.marc.']
 
-    members = ['Kieran4']
-    
-    for member in members:
-        user = pywikibot.User(site, member)
-        contribs = []
-        for (page, revid, time, comment) in user.contributions(128,
-                                                               namespaces = [0]):
-            contribs.append(page.title())	
+        # members = ['Kieran4', 'Brendandh', 'Gog the Mild', 'Seitzd', 'Robotam',
+        #            'Keith-264', 'Nyth83', 'Mmuroya', 'Navy2004', 'Secutor7',
+        #            'Ranger Steve', 'MisterBee1966']
 
-        # Calculate the cutoff date
-        cutoff = datetime.now(timezone.utc) - timedelta(days=args.cutoff*30)
-        matches = recommender.recommend(contribs, member, 'en', cutoff,
-                                        nrecs=args.nrecs, backoff=1, test=args.test)
-        
-        match_set = set([rec['item'] for rec in matches])
-        overlap = match_set & all_members
-        
-        total_recs += len(match_set)
-        total_overlap += len(overlap)
+        members = ['Kieran4']
 
-        print('Got {n} recommendations for User:{user}'.format(n=len(match_set),
-                                                               user=member))
-        print('Overlap with all members: {0}'.format(len(overlap)))
+        for member in members:
+                user = pywikibot.User(site, member)
+                contribs = []
+                for (page, revid, time, comment) in user.contributions(128,
+                                                                       namespaces = [0]):
+                        contribs.append(page.title())	
 
-    print('''Total statistics:
+                matches = recommender.recommend(contribs, member, 'en',
+                                                nrecs=args.nrecs, backoff=1, test=args.test)
+
+                match_set = set([rec['item'] for rec in matches])
+                overlap = match_set & all_members
+
+                total_recs += len(match_set)
+                total_overlap += len(overlap)
+
+                print('Got {n} recommendations for User:{user}'.format(n=len(match_set),
+                                                                       user=member))
+                print('Overlap with all members: {0}'.format(len(overlap)))
+
+        print('''Total statistics:
     Number of recommendations: {n}
     Overlap with all members: {o}
     % overlap: {p:.2}'''.format(n=total_recs, o=total_overlap,
                                 p=100*float(total_overlap)/float(total_recs)))
-    print('Recommendation test complete')
+        print('Recommendation test complete')
 	
 if __name__ == "__main__":
-    main()
+        main()

--- a/tool-labs/collab-rec/collaborator.py
+++ b/tool-labs/collab-rec/collaborator.py
@@ -198,7 +198,7 @@ class CollabRecommender:
 #        while backoff and self.thresh >= self.min_thresh and needed:
 #            self.thresh -= 1
 #            logging.info('Co-edit threshold is now {0}'.format(self.thresh))
-            recs = self.get_recs_at_coedit_threshold(username, contribs, self.test)
+        recs = self.get_recs_at_coedit_threshold(username, contribs, self.test)
 #            needed = nrecs - len(recs) > 0
 
         db.disconnect(self.dbconn, self.dbcursor)

--- a/tool-labs/collab-rec/collaborator.py
+++ b/tool-labs/collab-rec/collaborator.py
@@ -287,8 +287,8 @@ class CollabRecommender:
                 other_editors[user] = 1
 
             logging.info('found {0} stakeholders'.format(len(other_editors)))
-'''               
-            # Then we check minor edits and reverts, and keep those users who are
+              
+            '''# Then we check minor edits and reverts, and keep those users who are
             # not in the top 10% of users (see `self.exp_thresh`).
 
             # Users we've seen (so we don't re-run SQL queries all the time)...
@@ -332,8 +332,8 @@ class CollabRecommender:
                     if row['numedits'] < self.exp_thresh:
                         other_editors[user] = 1
 
-            logging.info('found {0} other editors in total'.format(len(other_editors)))
-'''
+            logging.info('found {0} other editors in total'.format(len(other_editors)))'''
+
             # Now we have all relevant stakeholders in the article, and can
             # compute the appropriate association.
             for user in other_editors:

--- a/tool-labs/collab-rec/collaborator.py
+++ b/tool-labs/collab-rec/collaborator.py
@@ -287,7 +287,7 @@ class CollabRecommender:
                 other_editors[user] = 1
 
             logging.info('found {0} stakeholders'.format(len(other_editors)))
-/*                
+'''               
             # Then we check minor edits and reverts, and keep those users who are
             # not in the top 10% of users (see `self.exp_thresh`).
 
@@ -333,7 +333,7 @@ class CollabRecommender:
                         other_editors[user] = 1
 
             logging.info('found {0} other editors in total'.format(len(other_editors)))
-*/
+'''
             # Now we have all relevant stakeholders in the article, and can
             # compute the appropriate association.
             for user in other_editors:


### PR DESCRIPTION
The updated collaborator.py will now filter out relevant reverts and once again include minor editors who fall under the specified total edits threshold.